### PR TITLE
Fix resource pack integration

### DIFF
--- a/src/main/java/pl/asie/debark/DebarkProxyClient.java
+++ b/src/main/java/pl/asie/debark/DebarkProxyClient.java
@@ -132,9 +132,13 @@ public class DebarkProxyClient extends DebarkProxyCommon {
                 } else {
                     event.getMap().setTextureEntry(new StrippedBarkColoredSprite(blockSide.toString(), logTopLocation, logSideLocation));
                 }
+            } else {
+                event.getMap().registerSprite(blockSide);
             }
             if (!ResourceUtils.textureExists(blockTop)) {
                 event.getMap().setTextureEntry(new LogColoredSprite(blockTop.toString(), logTopLocation, templateTop));
+            } else {
+                event.getMap().registerSprite(blockTop);
             }
         });
     }


### PR DESCRIPTION
Resolves an issue where when provided with a resource pack the sprite is not registered, resulting in a missing texture